### PR TITLE
fix: Remove hardcoded reference to master

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ impl Cli {
         }
 
         checkout(&base_branch);
-        pull(&self.remote, "master");
+        pull(&self.remote, &base_branch);
 
         if &current_branch != &base_branch {
             checkout(&current_branch);


### PR DESCRIPTION
I just tested the new release by running `git-absorb` from a feature branch. It correctly detected `main` as the base branch, but failed when pulling the origin:

```sh
$ git-absorb
Checking out main ...
Your branch is up to date with 'origin/main'.

Pulling origin master ...
fatal: couldn't find remote ref master
```

I think there is still a reference to master in https://github.com/arnau/git-absorb/blob/8dfa617ac4bf781113b059e75f006425c1850297/src/main.rs#L67

I believe that needs to be changed to `&base_branch` as well. As I've written in the commit message, this makes the assumption that the target branch has the same name as the base branch. I think this is a safe enough assumption and something that was being [done before](https://github.com/arnau/git-absorb/commit/2db1bc73d15d2fd0e91aa5dc51408836905d3561#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL39-L40)?

Note: I have not compiled or tested this so it's a bit of a shot in the dark!